### PR TITLE
Add feature to allow skip checking the xz path in encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,10 @@ $payBySquare = new PayBySquare([
 
 // Or when creating an instance without payment attributes
 $payBySquare = new PayBySquare(null, '/custom/path/to/xz');
+
+// Or even allow skip the path checking, if xz is installed, but fails the check
+$payBySquare->skipXzPathCheck(true);
+
 ```
 
 #### Raw Data String

--- a/src/Encoder.php
+++ b/src/Encoder.php
@@ -17,6 +17,13 @@ class Encoder
     private ?string $xzBinaryPath = null;
     
     /**
+     * @var bool Allow skip the XZ binary path check
+     */
+    public bool $skipXzPathCheck = false;
+    
+    
+
+    /**
      * @var array Common paths where XZ binary might be located
      */
     private array $commonXzPaths = [
@@ -137,6 +144,11 @@ class Encoder
     {
         // If path is already set, return it
         if ($this->xzBinaryPath !== null) {
+            // if allowed to skip
+            if($this->skipXzPathCheck) { 
+                return $this->xzBinaryPath;
+            }
+            // else check
             if (file_exists($this->xzBinaryPath) && is_executable($this->xzBinaryPath)) {
                 return $this->xzBinaryPath;
             }

--- a/src/PayBySquare.php
+++ b/src/PayBySquare.php
@@ -115,6 +115,20 @@ class PayBySquare
         }
     }
     
+
+    /**
+     * Allow skip of checking the Xz utility path
+     * 
+     * @param bool $skip
+     * @return bool
+     */
+    public function skipXzPathCheck(?bool $skip = true) :bool
+    {
+        $this->encoder->skipXzPathCheck = $skip;
+        return $this->encoder->skipXzPathCheck ;
+    }
+    
+
     /**
      * Create a new Payment object
      *


### PR DESCRIPTION
on some servers, because open basedir restrictions, the check says it does not exist, but the proc_open works fine. THis is to allow specificcally allow that check